### PR TITLE
xiaomi-mido: Add UCM configuration for xiaomi-mido

### DIFF
--- a/ucm2/xiaomi-mido/HiFi.conf
+++ b/ucm2/xiaomi-mido/HiFi.conf
@@ -1,0 +1,43 @@
+# Use case configuration for Xiaomi Redmi Note 4
+# All analog outputs/inputs connected to internal PM8953 codec,
+# speaker connected via AW87318CSR amplifier to Lineout.
+
+SectionVerb {
+	Value {
+		PlaybackPCM "plughw:${CardId},0"
+		CapturePCM "plughw:${CardId},1"
+	}
+}
+<platforms/msm8916/qdsp6-components.conf>
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	ConflictingDevice [
+		"Headphones"
+		"Earpiece"
+	]
+
+	EnableSequence [
+		cset "name='RX3 MIX1 INP1' RX1"
+		cset "name='LINEOUT' 1"
+		cset "name='RX3 Digital Volume' 115"
+	]
+
+	DisableSequence [
+		cset "name='RX3 Digital Volume' 0"
+		cset "name='LINEOUT' ZERO"
+		cset "name='RX3 MIX1 INP1' ZERO"
+	]
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 200
+	}
+}
+
+<codecs/msm8916-wcd/Earpiece.conf>
+<codecs/msm8916-wcd/Headphones.conf>
+<codecs/msm8916-wcd/PrimaryMic.conf>
+<codecs/msm8916-wcd/SecondaryMic.conf>
+<codecs/msm8916-wcd/HeadsetMic.conf>

--- a/ucm2/xiaomi-mido/xiaomi-mido.conf
+++ b/ucm2/xiaomi-mido/xiaomi-mido.conf
@@ -1,0 +1,6 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}


### PR DESCRIPTION
Speaker is connected to Diangu codec Lineout via an external amplifier.