### PR TITLE
alcatel-idol347: Add UCM configuration for Alcatel Idol 3 (4.7)

### DIFF
--- a/ucm2/alcatel-idol3/HiFi.conf
+++ b/ucm2/alcatel-idol3/HiFi.conf
@@ -1,0 +1,58 @@
+# Use case configuration for Alcatel OneTouch Idol 3.
+# The two speakers/earpieces are connected to external codec (TFA9897)
+# Headphones support requires writing a driver for AK4375
+
+Define {
+	WcdCapturePCM "hw:${CardId},0"
+}
+<platforms/msm8916/qdsp6-components.conf>
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	EnableSequence [
+		cset "name='Speaker Top Amp Input' Left"
+		cset "name='Speaker Bottom Amp Input' Right"
+		cset "name='Speaker Top Mode' Speaker"
+		cset "name='Speaker Bottom Mode' Speaker"
+		cset "name='Speaker Top Amp Switch' 1"
+		cset "name='Speaker Bottom Amp Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Top Amp Switch' 0"
+		cset "name='Speaker Bottom Amp Switch' 0"
+	]
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId},1"
+	}
+}
+
+SectionDevice."Earpiece" {
+	Comment "Earpiece playback"
+
+	EnableSequence [
+		cset "name='Speaker Top Amp Input' Left"
+		cset "name='Speaker Top Mode' Receiver"
+		cset "name='Speaker Top Amp Switch' 1"
+		cset "name='Speaker Bottom Amp Switch' 0"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Top Amp Switch' 0"
+		cset "name='Speaker Top Mode' Speaker"
+	]
+
+	Value {
+		PlaybackChannels 2
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},1"
+	}
+}
+
+<codecs/msm8916-wcd/PrimaryMic.conf>
+<codecs/msm8916-wcd/SecondaryMic.conf>
+<codecs/msm8916-wcd/HeadsetMic.conf>

--- a/ucm2/alcatel-idol3/alcatel-idol3.conf
+++ b/ucm2/alcatel-idol3/alcatel-idol3.conf
@@ -1,0 +1,6 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}


### PR DESCRIPTION
Earpiece and speaker use quaternary link on external tfa9897 amplifier.
Headphones (not supported yet) go through secondary link on ak4375 IC.

Signed-off-by: Vincent Knecht <vincent.knecht@mailoo.org>