### PR TITLE
alcatel-idol3: Change device numbers to account for primary or secondary

### DIFF
--- a/ucm2/alcatel-idol3/HiFi.conf
+++ b/ucm2/alcatel-idol3/HiFi.conf
@@ -3,7 +3,7 @@
 # Headphones support requires writing a driver for AK4375
 
 Define {
-	WcdCapturePCM "hw:${CardId},0"
+	WcdCapturePCM "hw:${CardId},1"
 }
 <platforms/msm8916/qdsp6-components.conf>
 
@@ -27,7 +27,7 @@ SectionDevice."Speaker" {
 	Value {
 		PlaybackChannels 2
 		PlaybackPriority 300
-		PlaybackPCM "hw:${CardId},1"
+		PlaybackPCM "hw:${CardId},2"
 	}
 }
 
@@ -49,7 +49,7 @@ SectionDevice."Earpiece" {
 	Value {
 		PlaybackChannels 2
 		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},1"
+		PlaybackPCM "hw:${CardId},2"
 	}
 }
 


### PR DESCRIPTION
idol3 doesn't use primary link and secondary link is not supported yet.
To prevent future change in device numbering when support is added for
secondary (headphones), and also allow using the same UCM config for
non-modem and modem dts, dummy primary link was added to device' DTS.

Change device numbers accordingly.