### PR TITLE
samsung-fortuna: Add UCM configuration for Samsung Galaxy Grand Prime

### DIFF
--- a/ucm2/msm8916-1mic/HiFi.conf
+++ b/ucm2/msm8916-1mic/HiFi.conf
@@ -1,0 +1,15 @@
+# Use case configuration for common MSM8916 devices. No SecondaryMic.
+# All analog outputs/inputs connected to internal PM8916 codec.
+
+Define {
+	WcdPlaybackPCM "hw:${CardId},0"
+	WcdCapturePCM "hw:${CardId},1"
+}
+<platforms/msm8916/qdsp6-components.conf>
+
+<codecs/msm8916-wcd/Speaker.conf>
+<codecs/msm8916-wcd/Earpiece.conf>
+<codecs/msm8916-wcd/Headphones.conf>
+
+<codecs/msm8916-wcd/PrimaryMic.conf>
+<codecs/msm8916-wcd/HeadsetMic.conf>

--- a/ucm2/msm8916-1mic/msm8916-1mic.conf
+++ b/ucm2/msm8916-1mic/msm8916-1mic.conf
@@ -1,0 +1,6 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}


### PR DESCRIPTION
Use case configuration for common MSM8916 devices. No SecondaryMic.
All analog outputs/inputs connected to internal PM8916 codec.