### PR TITLE
samsung-gmax: Add UCM configuration for Samsung Galaxy Grand Max

### DIFF
--- a/ucm2/samsung-gmax/HiFi.conf
+++ b/ucm2/samsung-gmax/HiFi.conf
@@ -1,0 +1,24 @@
+# Use case configuration for Samsung Galaxy Grand Max. No SecondaryMic.
+# Speaker connected to external codec (TFA9895)
+
+Define {
+	WcdPlaybackPCM "hw:${CardId},0"
+	WcdCapturePCM "hw:${CardId},1"
+}
+<platforms/msm8916/qdsp6-components.conf>
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Value {
+		PlaybackChannels 1
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},2"
+	}
+}
+
+<codecs/msm8916-wcd/Earpiece.conf>
+<codecs/msm8916-wcd/Headphones.conf>
+
+<codecs/msm8916-wcd/PrimaryMic.conf>
+<codecs/msm8916-wcd/HeadsetMic.conf>

--- a/ucm2/samsung-gmax/samsung-gmax.conf
+++ b/ucm2/samsung-gmax/samsung-gmax.conf
@@ -1,0 +1,6 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}


### PR DESCRIPTION
Use case configuration for Samsung Galaxy Grand Max. No SecondaryMic.
Speaker connected to external codec (TFA9895)

samsung-grandmax is too long so it's renamed into samsung-gmax here:

```
[   25.104571] qcom-apq8016-sbc 7702000.sound: ASoC: driver name too long 'samsung-grandmax' -> 'samsung-grandma'
```