### PR TITLE
acer-a1-724: Add UCM configuration for Acer Iconia Talk S A1-724

### DIFF
--- a/ucm2/acer-a1-724/HiFi.conf
+++ b/ucm2/acer-a1-724/HiFi.conf
@@ -1,0 +1,84 @@
+# Use case configuration for Acer Iconia Talk S A1-724.
+# All analog/digital outputs/inputs connected to internal PM8916 codec.
+
+Define {
+	WcdPlaybackPCM "hw:${CardId},0"
+	WcdCapturePCM "hw:${CardId},1"
+}
+<platforms/msm8916/qdsp6-components.conf>
+
+<codecs/msm8916-wcd/Speaker.conf>
+<codecs/msm8916-wcd/Earpiece.conf>
+<codecs/msm8916-wcd/Headphones.conf>
+
+SectionDevice."Mic1" {
+	Comment "Primary Digital Microphone"
+
+	ConflictingDevice [
+		"Headset"
+	]
+
+	EnableSequence [
+		cset "name='DEC2 MUX' DMIC2"
+		cset "name='CIC2 MUX' DMIC"
+	]
+
+	DisableSequence [
+		cset "name='DEC2 MUX' ZERO"
+	]
+
+	Value {
+		CapturePCM "${var:WcdCapturePCM}"
+		CaptureChannels 2
+		CapturePriority 300
+	}
+}
+
+SectionDevice."Mic2" {
+        Comment "Secondary Digital Microphone"
+
+        ConflictingDevice [
+                "Mic1"
+                "Headset"
+        ]
+
+        EnableSequence [
+                cset "name='DEC1 MUX' DMIC1"
+                cset "name='CIC1 MUX' DMIC"
+        ]
+
+        DisableSequence [
+                cset "name='DEC1 MUX' ZERO"
+        ]
+
+        Value {
+                CapturePCM "${var:WcdCapturePCM}"
+                CaptureChannels 2
+                CapturePriority 200
+        }
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='DEC1 MUX' ADC2"
+		cset "name='CIC1 MUX' AMIC"
+		cset "name='ADC2 Volume' 8"
+		cset "name='ADC2 MUX' INP2"
+	]
+
+	DisableSequence [
+		cset "name='ADC2 MUX' ZERO"
+		cset "name='ADC2 Volume' 0"
+		cset "name='DEC1 MUX' ZERO"
+	]
+
+	Value {
+		CapturePCM "${var:WcdCapturePCM}"
+		CaptureChannels 2
+		CapturePriority 400
+		# FIXME: Switching is broken
+		#JackControl "Mic Jack"
+	}
+}

--- a/ucm2/acer-a1-724/acer-a1-724.conf
+++ b/ucm2/acer-a1-724/acer-a1-724.conf
@@ -1,0 +1,6 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}


### PR DESCRIPTION
Use case configuration for Acer Iconia Talk S A1-724.
All analog/digital outputs/inputs connected to internal PM8916 codec.