### PR TITLE
Workaround for Earpiece.conf no sound

### DIFF
--- a/ucm2/codecs/msm8916-wcd/Earpiece.conf
+++ b/ucm2/codecs/msm8916-wcd/Earpiece.conf
@@ -7,7 +7,11 @@ SectionDevice."Earpiece" {
 
 	EnableSequence [
 		cset "name='RX1 MIX1 INP1' RX1"
+		cset "name='RX1 MIX1 INP2' RX2"
 		cset "name='RDAC2 MUX' RX1"
+		cset "name='EAR_S' 1"
+		## workaround: toggle switch to make it work
+		cset "name='EAR_S' 0"
 		cset "name='EAR_S' 1"
 		## gain to  0dB
 		cset "name='RX1 Digital Volume' 84"
@@ -17,6 +21,7 @@ SectionDevice."Earpiece" {
 		cset "name='RX1 Digital Volume' 0"
 		cset "name='EAR_S' 0"
 		cset "name='RX1 MIX1 INP1' ZERO"
+		cset "name='RX2 MIX1 INP1' ZERO"
 	]
 
 	Value {


### PR DESCRIPTION
When switching from `Speaker` (`HPHL`), after its DisableSequence (`HPHL` to `0`), `EAR_S` to `1` has no effect until it is toggled once (I'm on a device with disabled modem/`QDSP6`). Further more, route both stereo channels to the mono earpiece.