### PR TITLE
Fix SpeakerHPHL.conf

### DIFF
--- a/ucm2/codecs/msm8916-wcd/SpeakerHPHL.conf
+++ b/ucm2/codecs/msm8916-wcd/SpeakerHPHL.conf
@@ -8,6 +8,7 @@ SectionDevice."Speaker" {
 
 	EnableSequence [
 		cset "name='RX1 MIX1 INP1' RX1"
+		cset "name='RX1 MIX1 INP2' RX2"
 		cset "name='HPHL' 1"
 		## gain to  0dB
 		cset "name='RX1 Digital Volume' 84"
@@ -15,10 +16,11 @@ SectionDevice."Speaker" {
 	]
 
 	DisableSequence [
-		cset "name='RX1 Digital Volume' 0"
-		cset "name='HPHL EXT' 0"
-		cset "name='RX1 MIX1 INP1' ZERO"
 		cset "name='Speaker Switch' 0"
+		cset "name='RX1 Digital Volume' 0"
+		cset "name='HPHL' 0"
+		cset "name='RX1 MIX1 INP1' ZERO"
+		cset "name='RX1 MIX1 INP2' ZERO"
 	]
 
 	Value {


### PR DESCRIPTION
An `HPHL EXT` control was forgotten with the `Switch` update; allow stereo channels to be routed to mono output